### PR TITLE
fix: update broken URL

### DIFF
--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -10,4 +10,4 @@ Although deploying RisingWave with Docker Compose can also provide complete func
 
 Of course, if what you need is a single-node version of RisingWave and you understand the risks of machine downtime and insufficient resources, you can still use the Docker Compose method.
 
-As cluster deployment involves more specialized knowledge, readers are advised to refer to the latest official [Kubernetes](https://docs.risingwave.com/docs/current/risingwave-kubernetes/) and [Docker Compose](https://docs.risingwave.com/docs/current/risingwave-trial?method=docker-compose) deployment documentation.
+As cluster deployment involves more specialized knowledge, readers are advised to refer to the latest official [Kubernetes](https://docs.risingwave.com/docs/current/risingwave-kubernetes/) and [Docker Compose](https://docs.risingwave.com/docs/current/risingwave-docker-compose/) deployment documentation.


### PR DESCRIPTION
Fixes the broken URL encountered when visiting [deployment documentation](https://tutorials.risingwave.com/docs/production/install).